### PR TITLE
update ubi8 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-36 AS builder
+FROM registry.access.redhat.com/ubi8/nodejs-12:1 AS builder
 
 WORKDIR /opt/app-root/src
 
@@ -11,7 +11,7 @@ RUN cd client && npm ci
 
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-36
+FROM registry.access.redhat.com/ubi8/nodejs-12:1
 
 COPY --from=builder /opt/app-root/src/client/build client/build
 COPY public public


### PR DESCRIPTION
Fixes ibm-garage-cloud/planning#421

Use the current ubi8/nodejs-12 image to reduce security vulnerabilities identified by Vulnerability Advisor. 